### PR TITLE
Added early-fail for non JSON ticket responses.

### DIFF
--- a/htsget/exceptions.py
+++ b/htsget/exceptions.py
@@ -41,6 +41,27 @@ class InvalidJsonError(ProtocolError):
             "The server returned invalid JSON:{}".format(exception))
 
 
+class InvalidLeadingJsonError(ProtocolError):
+    """
+    The server returned invalid JSON, indicated by the first few bytes of the
+    response not containing a '{' char.
+    """
+    def __init__(self, first_char):
+        super(InvalidLeadingJsonError, self).__init__(
+            "The server returned invalid JSON; the first non whitespace "
+            "byte should be '{{' but is = '{}'".format(first_char))
+
+
+class TicketDecodeError(ProtocolError):
+    """
+    The server returned ticket data that could not be decoded.
+    """
+    def __init__(self, exception):
+        super(TicketDecodeError, self).__init__(
+            "The server returned ticket data that could not be decoded:{}".format(
+                exception))
+
+
 class MalformedJsonError(ProtocolError):
     """
     The server returned valid JSON, but it doesn't conform to the protocol.


### PR DESCRIPTION
Closes #24.

What do you think @jmtcsngr? The idea here is to stream the ticket request as well. We read the first 64K, try to decode it and then look at the first non-whitespace character. If these fail, we fail early.  Any feedback would be much appreciated.